### PR TITLE
Don't use "false" as default exit-node value

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -12,7 +12,7 @@ up() {
     --advertise-routes=${TAILSCALE_ADVERTISE_ROUTES} \
     --advertise-tags=${TAILSCALE_ADVERTISE_TAGS} \
     --authkey=${TAILSCALE_AUTH_KEY} \
-    --exit-node=${TAILSCALE_EXIT_NODE:-false} \
+    --exit-node=${TAILSCALE_EXIT_NODE} \
     --exit-node-allow-lan-access=${TAILSCALE_EXIT_NODE_ALLOW_LAN_ACCESS:-false} \
     --force-reauth=${TAILSCALE_FORCE_REAUTH:-false} \
     --host-routes=${TAILSCALE_HOST_ROUTES:-true} \


### PR DESCRIPTION
The `--exit-node` parameter expects an IP address instead of a boolean value. If an empty string is provided, the flag will be ignored and no exit node would be used.