### PR TITLE
Chore: Bump version to 1.32.3 (fixes CVEs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 
 ARG TARGETARCH
-ARG VERSION=1.32.2
+ARG VERSION=1.32.3
 
 RUN \
   apk add --no-cache iptables iproute2 ca-certificates bash \


### PR DESCRIPTION
## What

* Bump version to `1.32.3`

## Why

* Number of CVEs fixed in `1.32.3` https://tailscale.com/changelog/#2022-11-21-client