### PR TITLE
Update version to 1.34.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15
 
 ARG TARGETARCH
-ARG VERSION=1.34.1
+ARG VERSION=1.34.2
 
 RUN \
   apk add --no-cache iptables iproute2 ca-certificates bash \


### PR DESCRIPTION
Update version to 1.34.2 which fixes handling of a large number of SplitDNS domains while using an exit node.