### PR TITLE
Update Tailscale to version 1.76.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 
 ARG TARGETARCH
-ARG VERSION=1.68.1
+ARG VERSION=1.76.6
 
 RUN \
   apk add --no-cache iptables iproute2 ca-certificates bash \


### PR DESCRIPTION
Updates Tailscale to `1.76.6` released on November 8, 2024

Reference: https://tailscale.com/changelog#2024-11-08